### PR TITLE
支持多API Key，用分号`;`隔开

### DIFF
--- a/src/common/utils.ts
+++ b/src/common/utils.ts
@@ -3,7 +3,9 @@ const apiKeyStorageKey = 'apiKey'
 export async function getApiKey(): Promise<string> {
     return new Promise((resolve) => {
         chrome.storage.sync.get([apiKeyStorageKey], (items) => {
-            resolve(items?.[apiKeyStorageKey] ?? '')
+            const apiKeys = items?.[apiKeyStorageKey] ?? ''
+            const keys = apiKeys.split(',') // Split the API keys into an array
+            keys.length === 0 ? resolve(keys) : resolve(keys[Math.floor(Math.random() * keys.length)])
         })
     })
 }

--- a/src/common/utils.ts
+++ b/src/common/utils.ts
@@ -5,7 +5,7 @@ export async function getApiKey(): Promise<string> {
         chrome.storage.sync.get([apiKeyStorageKey], (items) => {
             const apiKeys = items?.[apiKeyStorageKey] ?? ''
             const keys = apiKeys.split(',') // Split the API keys into an array
-            keys.length === 0 ? resolve(keys) : resolve(keys[Math.floor(Math.random() * keys.length)])
+            keys.length === 0 ? resolve(apiKeys) : resolve(keys[Math.floor(Math.random() * keys.length)])
         })
     })
 }

--- a/src/content/translate.ts
+++ b/src/content/translate.ts
@@ -16,17 +16,7 @@ export interface TranslateResult {
 }
 
 export async function translate(query: TranslateQuery): Promise<TranslateResult> {
-    const apiKeys = await utils.getApiKey(); 
-    const keys = apiKeys.split(';'); // Split the API keys into an array
-    const key = keys[Math.floor(Math.random() * keys.length)]; // Select a random API key from the array
-    if (keys.length === 0) { // If there are only one key
-      return translateWithApiKey(query, apiKeys); // Use the original API key
-    } else {
-      return translateWithApiKey(query, key); // Use the randomly selected API key
-    }
-}
-
-export async function translateWithApiKey(query: TranslateQuery, apiKey: string): Promise<TranslateResult> {
+    const apiKey = await utils.getApiKey()
     const headers = {
         'Content-Type': 'application/json',
         Authorization: `Bearer ${apiKey}`,

--- a/src/content/translate.ts
+++ b/src/content/translate.ts
@@ -16,7 +16,17 @@ export interface TranslateResult {
 }
 
 export async function translate(query: TranslateQuery): Promise<TranslateResult> {
-    const apiKey = await utils.getApiKey()
+    const apiKeys = await utils.getApiKey(); 
+    const keys = apiKeys.split(';'); // Split the API keys into an array
+    const key = keys[Math.floor(Math.random() * keys.length)]; // Select a random API key from the array
+    if (keys.length === 0) { // If there are only one key
+      return translateWithApiKey(query, apiKeys); // Use the original API key
+    } else {
+      return translateWithApiKey(query, key); // Use the randomly selected API key
+    }
+}
+
+export async function translateWithApiKey(query: TranslateQuery, apiKey: string): Promise<TranslateResult> {
     const headers = {
         'Content-Type': 'application/json',
         Authorization: `Bearer ${apiKey}`,


### PR DESCRIPTION
由于OpenAI免费帐号限制，用多个API Key，可以作为一个资源池，随机挑选一个API Key使用。