### PR TITLE
fix: remove prettier parser option

### DIFF
--- a/.prettierrc.js
+++ b/.prettierrc.js
@@ -6,7 +6,6 @@ module.exports = {
     tabWidth: 4,
     useTabs: false,
     quoteProps: 'consistent',
-    parser: 'typescript',
     bracketSpacing: true,
     printWidth: 120,
 }

--- a/public/manifest.firefox.json
+++ b/public/manifest.firefox.json
@@ -1,38 +1,38 @@
 {
-  "manifest_version": 3,
+    "manifest_version": 3,
 
-  "name": "OpenAI Translator",
-  "description": "OpenAI-Translator is a Chrome extension that uses the ChatGPT API for translation.",
-  "version": "1.0",
+    "name": "OpenAI Translator",
+    "description": "OpenAI-Translator is a Chrome extension that uses the ChatGPT API for translation.",
+    "version": "1.0",
 
-  "options_ui": {
-    "page": "options.html"
-  },
+    "options_ui": {
+        "page": "options.html"
+    },
 
-  "action": {
-    "default_icon": "icon.png",
-    "default_popup": "popup.html"
-  },
+    "action": {
+        "default_icon": "icon.png",
+        "default_popup": "popup.html"
+    },
 
-  "content_scripts": [
-    {
-      "matches": ["<all_urls>"],
-      "all_frames": true,
-      "js": ["js/content_script.js"]
+    "content_scripts": [
+        {
+            "matches": ["<all_urls>"],
+            "all_frames": true,
+            "js": ["js/content_script.js"]
+        }
+    ],
+
+    "background": {
+        "scripts": ["js/background.js"]
+    },
+
+    "permissions": ["storage", "*://*.openai.com/*"],
+
+    "host_permissions": ["https://*.openai.com/"],
+
+    "browser_specific_settings": {
+        "gecko": {
+            "id": "openaitranslator@gmail.com"
+        }
     }
-  ],
-
-  "background": {
-    "scripts": ["js/background.js"]
-  },
-
-  "permissions": ["storage", "*://*.openai.com/*"],
-
-  "host_permissions": ["https://*.openai.com/"],
-
-  "browser_specific_settings": {
-    "gecko": {
-      "id": "openaitranslator@gmail.com"
-    }
-  }
 }

--- a/public/manifest.json
+++ b/public/manifest.json
@@ -1,35 +1,32 @@
 {
-  "manifest_version": 3,
+    "manifest_version": 3,
 
-  "name": "OpenAI Translator",
-  "description": "OpenAI-Translator is a Chrome extension that uses the ChatGPT API for translation.",
-  "version": "1.0",
+    "name": "OpenAI Translator",
+    "description": "OpenAI-Translator is a Chrome extension that uses the ChatGPT API for translation.",
+    "version": "1.0",
 
-  "options_ui": {
-    "page": "options.html"
-  },
+    "options_ui": {
+        "page": "options.html"
+    },
 
-  "action": {
-    "default_icon": "icon.png",
-    "default_popup": "popup.html"
-  },
+    "action": {
+        "default_icon": "icon.png",
+        "default_popup": "popup.html"
+    },
 
-  "content_scripts": [
-      {
-          "matches": ["<all_urls>"],
-          "all_frames": true,
-          "js": ["js/content_script.js"]
-      }
-  ],
+    "content_scripts": [
+        {
+            "matches": ["<all_urls>"],
+            "all_frames": true,
+            "js": ["js/content_script.js"]
+        }
+    ],
 
-  "background": {
-    "service_worker": "js/background.js"
-  },
+    "background": {
+        "service_worker": "js/background.js"
+    },
 
-  "permissions": [
-    "storage",
-    "tts"
-  ],
+    "permissions": ["storage", "tts"],
 
-  "host_permissions": ["https://*.openai.com/"]
+    "host_permissions": ["https://*.openai.com/"]
 }


### PR DESCRIPTION
remove the parser option to avoid Prettier raising an error while formatting the JSON file.

![prettier-error](https://user-images.githubusercontent.com/18044730/223597984-d7954a13-8ad2-49a8-a7f5-c8815c4511a0.png)
