### PR TITLE
fix(firefox): correct permissions to remove warning

### DIFF
--- a/public/manifest.firefox.json
+++ b/public/manifest.firefox.json
@@ -26,7 +26,7 @@
         "scripts": ["js/background.js"]
     },
 
-    "permissions": ["storage", "*://*.openai.com/*"],
+    "permissions": ["storage"],
 
     "host_permissions": ["https://*.openai.com/"],
 


### PR DESCRIPTION
this depends on #67
![correct-permissions](https://user-images.githubusercontent.com/18044730/223618882-52634665-26f0-4a52-b1f9-4c90bd51e81e.png)
