### PR TITLE
fix(firefox): getSelection not work on input and textarea elements

### DIFF
--- a/src/content_script/index.tsx
+++ b/src/content_script/index.tsx
@@ -169,7 +169,13 @@ async function showPopupThumb(text: string, x: number, y: number) {
 
 document.addEventListener('mouseup', (event: MouseEvent) => {
     window.setTimeout(async () => {
-        const text = (window.getSelection()?.toString() ?? '').trim()
+        let text = (window.getSelection()?.toString() ?? '').trim()
+        if (!text) {
+            if (event.target instanceof HTMLInputElement || event.target instanceof HTMLTextAreaElement) {
+                const elem = event.target
+                text = elem.value.substring(elem.selectionStart ?? 0, elem.selectionEnd ?? 0)
+            }
+        }
         ;(await utils.getSettings()).autoTranslate === true
             ? showPopupCard(event.pageX + 7, event.pageY + 7, text)
             : showPopupThumb(text, event.pageX + 7, event.pageY + 7)


### PR DESCRIPTION
> It is worth noting that currently getSelection() doesn't work on the content of textarea  and input elements in Firefox and Edge (Legacy)

ref: https://developer.mozilla.org/en-US/docs/Web/API/Window/getSelection#related_objects