### PR TITLE
chore: add tips for macOS installation in readme

### DIFF
--- a/README.md
+++ b/README.md
@@ -98,6 +98,52 @@ What began as a translation tool has now evolved to include surprisingly effecti
 
     <img width="200" src="https://user-images.githubusercontent.com/1206493/223917449-ed1ac19f-c43d-4b13-9888-79ba46ceb862.png" />
 
+  macOS 13 is currently known to have none of these prompts, so please do as follows:
+
+  1. Trust the developer and ask for a password:
+
+  `sudo spctl --master-disable`
+
+  2. Allow OpenAI Translator
+
+  `xattr -cr /Applications/OpenAI\ Translator.app`
+
+  If prompted with the following
+
+  ```
+  option -r not recognized
+  
+  usage: xattr [-slz] file [file ...]
+         xattr -p [-slz] attr_name file [file ...]
+         xattr -w [-sz] attr_name attr_value file [file ...]
+         xattr -d [-s] attr_name file [file ...]
+         xattr -c [-s] file [file ...]
+  
+  The first form lists the names of all xattrs on the given file(s).
+  The second form (-p) prints the value of the xattr attr_name.
+  The third form (-w) sets the value of the xattr attr_name to attr_value.
+  The fourth form (-d) deletes the xattr attr_name.
+  The fifth form (-c) deletes (clears) all xattrs.
+  
+  options:
+    -h: print this help
+    -s: act on symbolic links themselves rather than their targets
+    -l: print long format (attr_name: attr_value)
+    -z: compress or decompress (if compressed) attribute value in zip format
+  ```
+
+  3. Execute commands
+
+  `xattr -c /Applications/OpenAI\ Translator.app/*`
+
+  4. If the above command still does not work, try the following command:
+
+  `sudo xattr -d com.apple.quarantine /Applications/OpenAI\ Translator.app/`
+
+# 浏览器插件安装方法
+
+由于此插件还在 Chrome Store 审核中，所以现在需要手动下载和安装，敬请谅解。
+
 # Installation(Browser Extension)
 
 1. Go to the [Chrome Web Store](https://chrome.google.com/webstore/detail/openai-translator/ogjibjphoadhljaoicdnjnmgokohngcc) and install this extension.


### PR DESCRIPTION
macOS 13 打开“任何来源”选项打开 OpenAI Translator 仍然有已损坏提示，没有 "Open Anyway" 的选项，建议再额外提供一种加信任的方法
<img width="718" alt="image" src="https://user-images.githubusercontent.com/20554850/224081148-918bb486-a8df-4c84-88bc-9fbee43a0840.png">


参考 [PicGo/FAQ](https://github.com/Molunerfinn/PicGo/blob/dev/FAQ.md#13-macos%E7%B3%BB%E7%BB%9F%E5%AE%89%E8%A3%85%E5%AE%8Cpicgo%E6%98%BE%E7%A4%BA%E6%96%87%E4%BB%B6%E5%B7%B2%E6%8D%9F%E5%9D%8F%E6%88%96%E8%80%85%E5%AE%89%E8%A3%85%E5%AE%8C%E6%89%93%E5%BC%80%E6%B2%A1%E6%9C%89%E5%8F%8D%E5%BA%94)