### PR TITLE
feat: add Azure OpenAI service support

### DIFF
--- a/public/manifest.firefox.json
+++ b/public/manifest.firefox.json
@@ -28,7 +28,7 @@
 
     "permissions": ["storage"],
 
-    "host_permissions": ["https://*.openai.com/"],
+    "host_permissions": ["https://*.openai.com/", "https://*.openai.azure.com"],
 
     "browser_specific_settings": {
         "gecko": {

--- a/public/manifest.json
+++ b/public/manifest.json
@@ -28,5 +28,5 @@
 
     "permissions": ["storage", "tts"],
 
-    "host_permissions": ["https://*.openai.com/"]
+    "host_permissions": ["https://*.openai.com/", "https://*.openai.azure.com"]
 }

--- a/src/common/utils.ts
+++ b/src/common/utils.ts
@@ -1,10 +1,12 @@
 /* eslint-disable @typescript-eslint/no-explicit-any */
-import { TranslateMode } from '../content_script/translate'
+import { TranslateMode, Provider  } from '../content_script/translate'
 import { IBrowser } from './types'
 
 export interface ISettings {
     apiKeys: string
     apiURL: string
+    apiURLPath: string
+    provider: Provider | 'OpenAI'
     autoTranslate: boolean
     defaultTranslateMode: TranslateMode | 'nop'
     defaultTargetLanguage: string
@@ -12,6 +14,8 @@ export interface ISettings {
 }
 
 export const defaultAPIURL = 'https://api.openai.com'
+export const defaultAPIURLPath = '/v1/chat/completions'
+export const defaultProvider = 'OpenAI'
 
 export const defaultAutoTranslate = false
 export const defaultTargetLanguage = 'zh-Hans'
@@ -26,6 +30,8 @@ export async function getApiKey(): Promise<string> {
 const settingKeys: Record<keyof ISettings, number> = {
     apiKeys: 1,
     apiURL: 1,
+    apiURLPath: 1,
+    provider: 1,
     autoTranslate: 1,
     defaultTranslateMode: 1,
     defaultTargetLanguage: 1,
@@ -42,6 +48,12 @@ export async function getSettings(): Promise<ISettings> {
     }
     if (!settings.apiURL) {
         settings.apiURL = defaultAPIURL
+    }
+    if (!settings.apiURLPath) {
+        settings.apiURLPath = defaultAPIURLPath
+    }
+    if (!settings.provider) {
+        settings.provider = defaultProvider
     }
     if (settings.autoTranslate === undefined || settings.autoTranslate === null) {
         settings.autoTranslate = defaultAutoTranslate

--- a/src/popup/Settings.tsx
+++ b/src/popup/Settings.tsx
@@ -11,6 +11,7 @@ import { createForm } from '../components/Form'
 import { Button } from 'baseui/button'
 import './index.css'
 import { TranslateMode } from '../content_script/translate'
+import { Provider } from '../content_script/translate'
 import { Select, Value, Option } from 'baseui/select'
 import { Checkbox } from 'baseui/checkbox'
 import { supportLanguages } from '../content_script/lang'
@@ -55,6 +56,11 @@ interface ITranslateModeSelectorProps {
 interface AutoTranslateCheckboxProps {
     value?: boolean
     onChange?: (value: boolean) => void
+}
+
+interface IProviderSelectorProps {
+    value?: Provider | 'OpenAI'
+    onChange?: (value: Provider | 'OpenAI') => void
 }
 
 function TranslateModeSelector(props: ITranslateModeSelectorProps) {
@@ -102,6 +108,35 @@ function AutoTranslateCheckbox(props: AutoTranslateCheckboxProps) {
     )
 }
 
+function ProviderSelector(props: IProviderSelectorProps) {
+    return (
+        <Select
+            size='compact'
+            searchable={false}
+            clearable={false}
+            value={
+                props.value && [
+                    {
+                        id: props.value,
+                    },
+                ]
+            }
+            onChange={(params) => {
+                props.onChange?.(params.value[0].id as Provider | 'OpenAI')
+            }}
+            options={
+                [
+                    { label: 'OpenAI', id: 'OpenAI' },
+                    { label: 'Azure', id: 'Azure' },
+                ] as {
+                    label: string
+                    id: Provider
+                }[]
+            }
+        />
+    )
+}
+
 const engine = new Styletron()
 
 const { Form, FormItem, useForm } = createForm<utils.ISettings>()
@@ -115,6 +150,8 @@ export function Settings(props: IPopupProps) {
     const [values, setValues] = useState<utils.ISettings>({
         apiKeys: '',
         apiURL: utils.defaultAPIURL,
+        apiURLPath: utils.defaultAPIURLPath,
+        provider: utils.defaultProvider,
         autoTranslate: utils.defaultAutoTranslate,
         defaultTranslateMode: 'translate',
         defaultTargetLanguage: utils.defaultTargetLanguage,
@@ -181,6 +218,9 @@ export function Settings(props: IPopupProps) {
                         initialValues={values}
                         onValuesChange={onChange}
                     >
+                        <FormItem name='provider' label='Default Service Provider'>
+                            <ProviderSelector />
+                        </FormItem>
                         <FormItem
                             required
                             name='apiKeys'
@@ -203,6 +243,9 @@ export function Settings(props: IPopupProps) {
                             <Input autoFocus type='password' size='compact' />
                         </FormItem>
                         <FormItem required name='apiURL' label='API URL'>
+                            <Input size='compact' />
+                        </FormItem>
+                        <FormItem required name='apiURLPath' label='API URL Path'>
                             <Input size='compact' />
                         </FormItem>
                         <FormItem name='defaultTranslateMode' label='Default Translate Mode'>


### PR DESCRIPTION
## Background

As a user of the project, I would like to request the addition of support for Azure OpenAI. This would allow me to leverage the power of the Azure OpenAI platform, which offers cutting-edge AI technologies and services, including natural language processing, speech recognition, and computer vision.

I believe that adding support for Azure OpenAI would greatly enhance the functionality and usefulness of the project, and would be a valuable addition for users who are looking to integrate AI capabilities into their applications.

I look forward to hearing your thoughts on this proposal, and I am happy to provide additional information or assistance as needed. Thank you for considering this request.

https://azure.microsoft.com/en-us/blog/chatgpt-is-now-available-in-azure-openai-service/

Most of the APIs are the same, with only a few differences. refer to: https://learn.microsoft.com/en-us/azure/cognitive-services/openai/reference


## TODO

- [x] Add configurations
    - [x] Default Service Provider
    - [x]  API URL Path
- [x] Authentication
    - [x] Support for using `api-key`
- [ ] Modify request parameters and deal with response
    * https://learn.microsoft.com/en-us/azure/cognitive-services/openai/reference
  


I've added some base implementations here:

![2023-03-10 22-18-25屏幕截图](https://user-images.githubusercontent.com/3264292/224339149-0d4c13c4-261f-46ef-b99b-e8ae62837025.png)

