### PR TITLE
fix: macos universal build

### DIFF
--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -91,7 +91,7 @@ jobs:
           args: --target universal-apple-darwin
 
       - name: Build Tauri App
-        uses: tauri-apps/tauri-action@v0
+        uses: tauri-apps/tauri-action@dev
         if: matrix.platform != 'macos-latest'
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}

--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -66,7 +66,7 @@ jobs:
         if: matrix.platform == 'ubuntu-20.04'
         run: |
           sudo apt-get update
-          sudo apt-get install -y libgtk-3-dev libwebkit2gtk-4.0-dev libappindicator3-dev librsvg2-dev patchelf libx11-dev libxdo-dev
+          sudo apt-get install -y libgtk-3-dev libwebkit2gtk-4.0-dev libappindicator3-dev librsvg2-dev patchelf libx11-dev libxdo-dev libxcb-shape0-dev libxcb-xfixes0-dev
 
       - name: install frontend dependencies
         run: yarn install # change this to npm or pnpm depending on which one you use

--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -3,7 +3,6 @@ name: Release
 on:
   push:
     tags: [ v\d+\.\d+\.\d+ ]
-  workflow_dispatch:
 
 jobs:
   create-release:

--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -68,6 +68,11 @@ jobs:
           sudo apt-get update
           sudo apt-get install -y libgtk-3-dev libwebkit2gtk-4.0-dev libappindicator3-dev librsvg2-dev patchelf libx11-dev libxdo-dev libxcb-shape0-dev libxcb-xfixes0-dev
 
+      - name: install dependencies (mac only)
+        if: matrix.platform == 'macos-latest'
+        run: |
+          rustup target add aarch64-apple-darwin
+
       - name: install frontend dependencies
         run: yarn install # change this to npm or pnpm depending on which one you use
 

--- a/.github/workflows/test-build.yaml
+++ b/.github/workflows/test-build.yaml
@@ -39,7 +39,7 @@ jobs:
         run: yarn install # change this to npm or pnpm depending on which one you use
 
       - name: Build Tauri App (MacOS Universal)
-        uses: tauri-apps/tauri-action@v0
+        uses: tauri-apps/tauri-action@dev
         if: matrix.platform == 'macos-latest'
         id: tauri-action-mac
         env:
@@ -49,7 +49,7 @@ jobs:
           args: --target universal-apple-darwin
 
       - name: Build Tauri App
-        uses: tauri-apps/tauri-action@v0
+        uses: tauri-apps/tauri-action@dev
         if: matrix.platform != 'macos-latest'
         id: tauri-action
         env:

--- a/.github/workflows/test-build.yaml
+++ b/.github/workflows/test-build.yaml
@@ -30,6 +30,11 @@ jobs:
           sudo apt-get update
           sudo apt-get install -y libgtk-3-dev libwebkit2gtk-4.0-dev libappindicator3-dev librsvg2-dev patchelf libx11-dev libxdo-dev libxcb-shape0-dev libxcb-xfixes0-dev
 
+      - name: install dependencies (mac only)
+        if: matrix.platform == 'macos-latest'
+        run: |
+          rustup target add aarch64-apple-darwin
+
       - name: install frontend dependencies
         run: yarn install # change this to npm or pnpm depending on which one you use
 

--- a/.github/workflows/test-build.yaml
+++ b/.github/workflows/test-build.yaml
@@ -1,0 +1,78 @@
+name: Release
+
+on:
+  workflow_dispatch:
+
+jobs:
+  build-tauri:
+    permissions:
+      contents: write
+    strategy:
+      fail-fast: false
+      matrix:
+        platform: [macos-latest, ubuntu-20.04, windows-latest]
+
+    runs-on: ${{ matrix.platform }}
+    steps:
+      - uses: actions/checkout@v3
+
+      - name: setup node
+        uses: actions/setup-node@v3
+        with:
+          node-version: 16
+
+      - name: install Rust stable
+        uses: dtolnay/rust-toolchain@stable
+
+      - name: install dependencies (ubuntu only)
+        if: matrix.platform == 'ubuntu-20.04'
+        run: |
+          sudo apt-get update
+          sudo apt-get install -y libgtk-3-dev libwebkit2gtk-4.0-dev libappindicator3-dev librsvg2-dev patchelf libx11-dev libxdo-dev libxcb-shape0-dev libxcb-xfixes0-dev
+
+      - name: install frontend dependencies
+        run: yarn install # change this to npm or pnpm depending on which one you use
+
+      - name: Build Tauri App (MacOS Universal)
+        uses: tauri-apps/tauri-action@v0
+        if: matrix.platform == 'macos-latest'
+        id: tauri-action
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        with:
+          releaseId: test-release
+          args: --target universal-apple-darwin
+
+      - name: Build Tauri App
+        uses: tauri-apps/tauri-action@v0
+        if: matrix.platform != 'macos-latest'
+        id: tauri-action
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        with:
+          releaseId: test-release
+
+      - name: Upload artifact
+        uses: actions/upload-artifact@v3
+        with:
+          name: tauri-client-app-artifact
+          path: |
+            ${{ fromJSON(steps.tauri-action.outputs.artifactPaths)[0] }}
+            ${{ fromJSON(steps.tauri-action.outputs.artifactPaths)[1] }}
+
+
+  build-browser-extension:
+    runs-on: ubuntu-22.04
+
+    steps:
+      - uses: actions/checkout@v3
+      - uses: actions/setup-node@v3
+        with:
+          node-version: 18
+
+      - name: Install dependencies
+        run: yarn install
+
+      - name: Build
+        run: make build
+      # todo: upload browser extension artifacts

--- a/.github/workflows/test-build.yaml
+++ b/.github/workflows/test-build.yaml
@@ -1,4 +1,4 @@
-name: Release
+name: Test Build
 
 on:
   workflow_dispatch:

--- a/.github/workflows/test-build.yaml
+++ b/.github/workflows/test-build.yaml
@@ -62,8 +62,8 @@ jobs:
         with:
           name: tauri-client-app-artifact
           path: |
-            ${{ fromJSON(steps.tauri-action-mac.outputs.artifactPaths) }}
-            ${{ fromJSON(steps.tauri-action.outputs.artifactPaths) }}
+            ${{ fromJSON(steps.tauri-action-mac.outputs.artifactPaths)[0] }}
+            ${{ fromJSON(steps.tauri-action.outputs.artifactPaths)[0] }}
 
 
   build-browser-extension:

--- a/.github/workflows/test-build.yaml
+++ b/.github/workflows/test-build.yaml
@@ -36,7 +36,7 @@ jobs:
       - name: Build Tauri App (MacOS Universal)
         uses: tauri-apps/tauri-action@v0
         if: matrix.platform == 'macos-latest'
-        id: tauri-action
+        id: tauri-action-mac
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
         with:
@@ -57,8 +57,8 @@ jobs:
         with:
           name: tauri-client-app-artifact
           path: |
-            ${{ fromJSON(steps.tauri-action.outputs.artifactPaths)[0] }}
-            ${{ fromJSON(steps.tauri-action.outputs.artifactPaths)[1] }}
+            ${{ fromJSON(steps.tauri-action-mac.outputs.artifactPaths) }}
+            ${{ fromJSON(steps.tauri-action.outputs.artifactPaths) }}
 
 
   build-browser-extension:

--- a/src-tauri/src/utils.rs
+++ b/src-tauri/src/utils.rs
@@ -4,15 +4,6 @@ use tauri::Manager;
 
 use crate::APP_HANDLE;
 
-static ASCII_LOWER: [char; 26] = [
-    'a', 'b', 'c', 'd', 'e', 
-    'f', 'g', 'h', 'i', 'j', 
-    'k', 'l', 'm', 'n', 'o',
-    'p', 'q', 'r', 's', 't', 
-    'u', 'v', 'w', 'x', 'y', 
-    'z',
-];
-
 #[cfg(target_os = "windows")]
 pub fn copy() {
     use enigo::*;
@@ -39,9 +30,6 @@ pub fn copy() {
     enigo.key_up(Key::Space);
     enigo.key_up(Key::Tab);
     enigo.key_up(Key::Option);
-    for c in ASCII_LOWER.iter() {
-        enigo.key_up(Key::Layout(*c));
-    }
     enigo.key_down(Key::Meta);
     enigo.key_click(Key::Layout('c'));
     // enigo.key_down(Key::Layout('c'));


### PR DESCRIPTION
Right now the github action only output x64 (Intel chip) build for MacOS. This PR should allow the action to release a universal build.

Also added a workflow to trigger manual build for testing.