### PR TITLE
fix: when window minimized, shortcut key invalid

### DIFF
--- a/src-tauri/src/windows.rs
+++ b/src-tauri/src/windows.rs
@@ -1,6 +1,6 @@
 use crate::utils;
 use crate::APP_HANDLE;
-use tauri::{Manager, LogicalPosition, PhysicalPosition};
+use tauri::{LogicalPosition, Manager, PhysicalPosition};
 #[cfg(target_os = "windows")]
 use window_shadows::set_shadow;
 #[cfg(target_os = "linux")]
@@ -73,6 +73,7 @@ pub fn show_main_window() {
                     .set_position(LogicalPosition::new(x as f64, y as f64))
                     .unwrap();
             } else {
+                window.unminimize().unwrap();
                 window
                     .set_position(PhysicalPosition::new(x as f64, y as f64))
                     .unwrap();


### PR DESCRIPTION
1. Bug: clicking the **minimize icon** of the window, shortcut keys cannot bring up the window again.
2. Click **the blank part** to minimize not affected the shortcut keys.

It's seems the operator 1 is minimize the window, but operator 2 is hide.

I try `window.unminimize()` when call `show_main_window()`, it's fixed.

The last, thank you for your interesting creation😊.

![image](https://user-images.githubusercontent.com/41513919/224490217-b575ee63-701c-4ad2-9394-c46eb259c7fd.png)


