### PR TITLE
hide the window instead of closing it

### DIFF
--- a/src/tauri/App.tsx
+++ b/src/tauri/App.tsx
@@ -45,7 +45,7 @@ export function App() {
             appWindow.maximize()
         }
         function handleClose() {
-            appWindow.close()
+            appWindow.hide()
         }
         minimizeIconRef.current?.addEventListener('click', handleMinimize)
         maximizeIconRef.current?.addEventListener('click', handleMaximize)


### PR DESCRIPTION
Because the system tray is already supported, modify the behavior of the close button : hide the window instead of closing it.


I found that calling **window. close()** will not trigger the **CloseRequested** event.
So this code only works when the native close button is used. 
Windows and Linux have used **window.set_decorations (false)** hides the native close button.

https://github.com/yetone/openai-translator/blob/d841aec397bce21ee55e3c193177e8268bf6a90c/src-tauri/src/main.rs#L72-L76