### PR TITLE
Support installing OpenAITranslator from winget

### DIFF
--- a/.github/workflows/winget.yml
+++ b/.github/workflows/winget.yml
@@ -1,0 +1,15 @@
+name: Publish to WinGet
+on:
+  release:
+    types: [released]
+jobs:
+  publish:
+    # Action can only be run on windows
+    runs-on: windows-latest
+    steps:
+      - uses: vedantmgoyal2009/winget-releaser@v2
+        with:
+          identifier: yetone.OpenAITranslator
+          max-versions-to-keep: 5 # keep only latest 5 versions
+          installers-regex: '\.msi$' # Only .msi files
+          token: ${{ secrets.WINGET_TOKEN }}

--- a/README-CN.md
+++ b/README-CN.md
@@ -67,6 +67,14 @@
 
 # 桌面应用版安装方法
 
+## 通过 [winget](https://github.com/microsoft/winget-cli)安装 (仅支持 windows)
+
+```sh
+winget install yetone.OpenAITranslator
+```
+
+## 手动安装
+
 1. 去 [Release](https://github.com/yetone/openai-translator/releases) 页面下载你对应的操作系统的安装包
 
 2. 安装此应用

--- a/README.md
+++ b/README.md
@@ -72,6 +72,14 @@ What began as a translation tool has now evolved to include surprisingly effecti
 
 # Installation(Desktop App)
 
+## Install it from [winget](https://github.com/microsoft/winget-cli)(windows only)
+
+```sh
+winget install yetone.OpenAITranslator
+```
+
+## Install it manually
+
 1. Download zip package per OS from [Release](https://github.com/yetone/openai-translator/releases)
 
 2. Install the App!


### PR DESCRIPTION
Through the [PR](https://github.com/microsoft/winget-pkgs/pull/99321),  OpenAI Translator has been added to Winget. Windows users can now install it by executing the following command:

```sh
winget install yetone.OpenAITranslator
```

To better support Winget, we can integrate it into GitHub Actions. After that, once a new version is released, CI will automatically update that to Winget. Before merging this PR, please follow these steps:

1. Please add a GitHub token with public_repo and workflow scopes as a repository secret and rename the secret name to "WINGET_TOKEN" in the workflow.
2. Fork [microsoft/winget-pkgs](https://github.com/microsoft/winget-pkgs) under @yetone 

See [more info](https://github.com/vedantmgoyal2009/winget-releaser) about winget action.