### PR TITLE
feat: add pdf support to chrome using contextmenu

### DIFF
--- a/src/background/index.ts
+++ b/src/background/index.ts
@@ -42,27 +42,27 @@ if (isFirefox) {
             chrome.tts.stop()
         }
     })
-    chrome.contextMenus.create(
-        {
-            id: 'open-translator',
-            type: 'normal',
-            title: 'OpenAI Translator',
-            contexts: ['page', 'selection'],
-        },
-        () => {
-            chrome.runtime.lastError
-        }
-    )
-    chrome.contextMenus.onClicked.addListener(function (info, tab) {
-        if (tab?.id) {
-            chrome.tabs.sendMessage(tab.id, {
-                type: 'open-translator',
-                info,
-                tab,
-            })
-        }
-    })
 }
+
+browser.contextMenus.create(
+    {
+        id: 'open-translator',
+        type: 'normal',
+        title: 'OpenAI Translator',
+        contexts: ['page', 'selection'],
+    },
+    () => {
+        browser.runtime.lastError
+    }
+)
+browser.contextMenus.onClicked.addListener(async function (info, _tab) {
+    const [tab] = await chrome.tabs.query({ active: true })
+    tab.id &&
+        browser.tabs.sendMessage(tab.id, {
+            type: 'open-translator',
+            info,
+        })
+})
 
 type FetchMessage = {
     type: string

--- a/src/content_script/index.tsx
+++ b/src/content_script/index.tsx
@@ -183,7 +183,7 @@ async function main() {
 
     browser.runtime.onMessage.addListener(function (request) {
         if (request.type === 'open-translator') {
-            const text = window.getSelection()?.toString().trim() ?? ''
+            const text = request.info.selectionText ?? ''
             showPopupCard(lastMouseEvent?.pageX ?? 0 + 7, lastMouseEvent?.pageY ?? 0 + 7, text)
         }
     })


### PR DESCRIPTION
Implementing support for pdf through contextmenu, only works in chrome, because firefox seems does not support running content scripts on pdf pages.(https://bugzilla.mozilla.org/show_bug.cgi?id=1454760)
However, there are some positioning issues because mouse events cannot be triggered on a pdf pages.

![image](https://user-images.githubusercontent.com/18044730/224887578-f3099cf3-5829-42bb-a89f-fb7aeb27afbd.png)
