### PR TITLE
Improve the accuracy of detecting Korean and Japanese

### DIFF
--- a/src/content_script/lang.ts
+++ b/src/content_script/lang.ts
@@ -123,7 +123,7 @@ export async function detectLang(text: string): Promise<string | null> {
 export async function _detectLang(text: string): Promise<string | null> {
     const lang = await langGuesser.detect(text)
     if (lang !== 'unknown') {
-        if (lang !== 'en' && lang !== 'zh' && lang !== 'zh-TW') {
+        if (!["en", "zh", "zh-TW", "ko", "ja"].includes(lang)) {
             const res = langDetector.detect(text, 1)
             if (res.length > 0) {
                 return res[0][0]

--- a/src/content_script/lang.ts
+++ b/src/content_script/lang.ts
@@ -123,7 +123,7 @@ export async function detectLang(text: string): Promise<string | null> {
 export async function _detectLang(text: string): Promise<string | null> {
     const lang = await langGuesser.detect(text)
     if (lang !== 'unknown') {
-        if (!["en", "zh", "zh-TW", "ko", "ja"].includes(lang)) {
+        if (!['en', 'zh', 'zh-TW', 'ko', 'ja'].includes(lang)) {
             const res = langDetector.detect(text, 1)
             if (res.length > 0) {
                 return res[0][0]


### PR DESCRIPTION
Using the dataset from [Tatoeba](https://tatoeba.org/eng/downloads), approximately 10 million sentences in various languages were tested for accuracy using [languagedetect](https://www.npmjs.com/package/languagedetect) and [guesslanguage-ng](https://github.com/yetone/guessLanguage.ts). The overall results were disappointing. Overall, languagedetect performed slightly better than guesslanguage-ng, but languagedetect does not support East Asian languages, so the results of guesslanguage-ng are preferred for Japanese and Korean.