### PR TITLE
feat: support RTL(right-to-left) text (resolves #303)

### DIFF
--- a/src/content_script/PopupCard.tsx
+++ b/src/content_script/PopupCard.tsx
@@ -2,7 +2,7 @@ import React, { useCallback, useEffect, useRef, useState } from 'react'
 import toast, { Toaster } from 'react-hot-toast'
 import { Client as Styletron } from 'styletron-engine-atomic'
 import { Provider as StyletronProvider } from 'styletron-react'
-import { BaseProvider } from 'baseui'
+import { BaseProvider, Theme } from 'baseui'
 import { Textarea } from 'baseui/textarea'
 import icon from './assets/images/icon.png'
 import { createUseStyles } from 'react-jss'
@@ -416,6 +416,16 @@ export function PopupCard(props: IPopupCardProps) {
     }, [originalText, translateMode])
 
     const [actionStr, setActionStr] = useState('')
+
+    useEffect(() => {
+        const editor = editorRef.current
+        if (!editor) return
+        editor.dir = ['ar', 'fa', 'he', 'ug', 'ur'].includes(detectFrom) ? 'rtl' : 'ltr'
+    }, [detectFrom, actionStr])
+    const [translatedLanguageDirection, setTranslatedLanguageDirection] = useState<Theme['direction']>('ltr')
+    useEffect(() => {
+        setTranslatedLanguageDirection(['ar', 'fa', 'he', 'ug', 'ur'].includes(detectTo) ? 'rtl' : 'ltr')
+    }, [detectTo])
 
     const headerRef = useRef<HTMLDivElement>(null)
 
@@ -1048,6 +1058,7 @@ export function PopupCard(props: IPopupCardProps) {
                                                                         translateMode === 'explain-code'
                                                                             ? 'monospace'
                                                                             : 'inherit',
+                                                                    textalign: 'start',
                                                                 },
                                                             },
                                                         }}
@@ -1173,7 +1184,10 @@ export function PopupCard(props: IPopupCardProps) {
                                         </div>
                                     </div>
                                     {originalText !== '' && (
-                                        <div className={styles.popupCardTranslatedContainer}>
+                                        <div
+                                            className={styles.popupCardTranslatedContainer}
+                                            dir={translatedLanguageDirection}
+                                        >
                                             {actionStr && (
                                                 <div
                                                     className={clsx({

--- a/src/content_script/lang.ts
+++ b/src/content_script/lang.ts
@@ -71,8 +71,10 @@ export const supportLanguages: [string, string][] = [
     ['ka', 'ქართული'],
     ['kk', 'Қазақ'],
     ['mn', 'Монгол хэл'],
-    ['vi', 'Tiếng Việt'],
     ['tr', 'Türkçe'],
+    ['ug', 'ئۇيغۇر تىلى'],
+    ['ur', 'اردو'],
+    ['vi', 'Tiếng Việt'],
 ]
 
 export const langMap: Map<string, string> = new Map(supportLanguages)


### PR DESCRIPTION
# Screenshots
## RTL to LTR
![rtl-ltr](https://user-images.githubusercontent.com/20166026/225365474-3dd5fbd4-40ab-494d-ad17-128a6f91e415.png)
## RTL to RTL
![rtl-rtl](https://user-images.githubusercontent.com/20166026/225365463-838186f2-1cbb-48f5-a565-7dd9e7d428b0.png)
## LTR to RTL
![ltr-rtl](https://user-images.githubusercontent.com/20166026/225365441-b30b3877-7314-4555-92e2-f05c9db983f7.png)

P.S.: The UI framework Base Web has a [theme option](https://baseweb.design/components/tooltip/) for text direction, but it doesn't seem to function. Perhaps when i18n of the whole UI is implemented, we could add the 'dir' attribute to the HTML element to make it effective.
