### PR TITLE
chore(ci): bump `typos` to v1.13.24

### DIFF
--- a/.github/workflows/lint.yaml
+++ b/.github/workflows/lint.yaml
@@ -16,7 +16,7 @@ jobs:
       - name: Checkout Actions Repository
         uses: actions/checkout@v3
       - name: Check spelling with custom config file
-        uses: crate-ci/typos@v1.13.14
+        uses: crate-ci/typos@v1.13.24
         with:
           config: ./typos.toml
 


### PR DESCRIPTION
Bump the `typos` in CI lint to >= [v1.13.23](https://github.com/crate-ci/typos/releases/tag/v1.13.23) to avoid Docker builds.

Result: https://github.com/WaterLemons2k/openai-translator/actions/runs/4434204025/jobs/7779963871