### PR TITLE
fix: old MacOS tauri app blank screen

### DIFF
--- a/src/common/hooks/useThemeDetector.ts
+++ b/src/common/hooks/useThemeDetector.ts
@@ -9,8 +9,10 @@ export const useThemeDetector = () => {
 
     useEffect(() => {
         const darkThemeMq = window.matchMedia('(prefers-color-scheme: dark)')
-        darkThemeMq.addEventListener('change', mqListener)
-        return () => darkThemeMq.removeEventListener('change', mqListener)
+        if (typeof darkThemeMq.addEventListener === 'function') {
+            darkThemeMq.addEventListener('change', mqListener)
+            return () => darkThemeMq.removeEventListener('change', mqListener)
+        }
     }, [mqListener])
 
     return isDarkTheme


### PR DESCRIPTION
按照 [这里](https://mobile.twitter.com/EmmerichBret/status/1507634652680540164/photo/1) 所提示的，在老版本的macos 不支持 给`prefers-color-scheme` 添加 `addEventListener`。

不过目前没有找到可供测试的（big sur，Catalina）系统。如果是这个的问题，那么这个补丁应该可以修复。

希望有老系统的可以测试下。

编译过的测试版本 [OpenAI Translator.app.zip](https://github.com/yetone/openai-translator/files/10999127/OpenAI.Translator.app.zip)



下面是测试用的patch，可以使 tauri 打开devtools。
```
diff --git a/src-tauri/Cargo.toml b/src-tauri/Cargo.toml
index 6bd5181..7c3b3ea 100644
--- a/src-tauri/Cargo.toml
+++ b/src-tauri/Cargo.toml
@@ -17,7 +17,7 @@ tauri-build = { version = "1.2.1", features = [] }
 [dependencies]
 serde_json = "1.0"
 serde = { version = "1.0", features = ["derive"] }
-tauri = { version = "1.2.4", features = ["clipboard-all", "dialog-message", "fs-read-dir", "fs-read-file", "fs-write-file", "global-shortcut-all", "notification-all", "shell-open", "system-tray", "window-all", "windows7-compat"] }
+tauri = { version = "1.2.4", features = ["clipboard-all", "devtools", "dialog-message", "fs-read-dir", "fs-read-file", "fs-write-file", "global-shortcut-all", "notification-all", "shell-open", "system-tray", "window-all", "windows7-compat"] }
 window-shadows = "0.2.1"
 once_cell = "1.17.1"
 clipboard = "0.5.0"
```