### PR TITLE
fix: change tauri app esbuild target to es2015

### DIFF
--- a/build-tauri.mjs
+++ b/build-tauri.mjs
@@ -20,6 +20,7 @@ const config = {
     minify: true,
     legalComments: 'none',
     sourcemap: true,
+    target: "es2015",
     loader: {
         '.png': 'dataurl',
         '.jpg': 'dataurl',


### PR DESCRIPTION
这回应该可以了。在Catalina下测试通过了。

tauri是用`build-tauri.mjs`去build。

不知道为什么在TSconfig里面改，在这里不起作用。