### PR TITLE
Remove the insertion of "content_script.css" from the content page.

### DIFF
--- a/build.mjs
+++ b/build.mjs
@@ -56,7 +56,6 @@ async function build() {
     const commonFiles = [
         { src: `${browserExtensionOutDir}/content_script/index.js`, dst: 'js/content_script.js' },
         { src: `${browserExtensionOutDir}/content_script/index.js.map`, dst: 'js/content_script.js.map' },
-        { src: `${browserExtensionOutDir}/content_script/index.css`, dst: 'css/content_script.css' },
         { src: `${browserExtensionOutDir}/background/index.js`, dst: 'js/background.js' },
         { src: `${browserExtensionOutDir}/options/index.js`, dst: 'js/options.js' },
         { src: `${browserExtensionOutDir}/options/index.css`, dst: 'css/options.css' },
@@ -86,8 +85,7 @@ async function build() {
     // userscript
     await copyFiles(
         [
-            { src: `${browserExtensionOutDir}/content_script/index.js`, dst: 'index.js' },
-            { src: `${browserExtensionOutDir}/content_script/index.css`, dst: 'index.css' },
+            { src: `${browserExtensionOutDir}/content_script/index.js`, dst: 'index.js' }
         ],
         `./${userscriptOutDir}`
     )

--- a/public/manifest.firefox.json
+++ b/public/manifest.firefox.json
@@ -18,8 +18,7 @@
         {
             "matches": ["<all_urls>"],
             "all_frames": true,
-            "js": ["js/content_script.js"],
-            "css": ["css/content_script.css"]
+            "js": ["js/content_script.js"]
         }
     ],
 

--- a/public/manifest.json
+++ b/public/manifest.json
@@ -25,8 +25,7 @@
         {
             "matches": ["<all_urls>"],
             "all_frames": true,
-            "js": ["js/content_script.js"],
-            "css": ["css/content_script.css"]
+            "js": ["js/content_script.js"]
         }
     ],
 

--- a/public/userscript.js
+++ b/public/userscript.js
@@ -9,11 +9,6 @@
 // @icon            https://cdn.jsdelivr.net/gh/yetone/openai-translator@v0.1.0/public/icon.png
 // @match           *://*/*
 // @require         https://cdn.jsdelivr.net/gh/yetone/openai-translator@v0.1.0/dist/userscript/index.js
-// @grant           GM.setValue
-// @grant           GM.getValue
-// @grant           GM_xmlhttpRequest
-// @grant           GM_addStyle
-// @grant           GM_getResourceText
 // @license         MIT
 // ==/UserScript==
 

--- a/public/userscript.js
+++ b/public/userscript.js
@@ -9,7 +9,6 @@
 // @icon            https://cdn.jsdelivr.net/gh/yetone/openai-translator@v0.1.0/public/icon.png
 // @match           *://*/*
 // @require         https://cdn.jsdelivr.net/gh/yetone/openai-translator@v0.1.0/dist/userscript/index.js
-// @resource        MAIN_CSS https://cdn.jsdelivr.net/gh/yetone/openai-translator@v0.1.0/dist/userscript/index.css
 // @grant           GM.setValue
 // @grant           GM.getValue
 // @grant           GM_xmlhttpRequest
@@ -21,6 +20,4 @@
 /* eslint-disable no-undef */
 ;(function () {
     'use strict'
-    const css = GM_getResourceText('MAIN_CSS')
-    GM_addStyle(css)
 })()


### PR DESCRIPTION
看到使用了inline-import插件，所以在浏览器环境可以移除content_script.css插入到内容页面，防止可能出现的样式覆盖。
Seeing the use of the "inline-import" plugin, it is possible to remove the insertion of content_script.css into the content page in the browser environment to prevent potential style overrides.