### PR TITLE
🐛 fix: prevent from submisson when hitting Enter in composition

### DIFF
--- a/src/content_script/PopupCard.tsx
+++ b/src/content_script/PopupCard.tsx
@@ -1159,7 +1159,7 @@ export function PopupCard(props: IPopupCardProps) {
                                                                   )
                                                         }
                                                         onChange={(e) => setEditableText(e.target.value)}
-                                                        onKeyDown={(e) => {
+                                                        onKeyPress={(e) => {
                                                             if (e.key === 'Enter') {
                                                                 if (!e.shiftKey) {
                                                                     e.preventDefault()


### PR DESCRIPTION
# bug说明
When users hit Enter while typing, it directly triggers translation, resulting in a poor experience for entering English text in spelling mode.

当用户拼写时敲击回车会直接触发翻译，使得在拼写模式下输入英文体验很不好。
# 演示：
- 修复前
![20230320190806_rec_](https://user-images.githubusercontent.com/57596934/226322439-8ea9b192-7a72-41d6-9045-93ebf1771264.gif)
- 修复后
![20230320190912_rec_](https://user-images.githubusercontent.com/57596934/226322634-4b710698-82ea-4711-b2f8-dbde0c39efc2.gif)

