### PR TITLE
opt rust code, remove unsafe static mut by using AtomicBool and Mutex

### DIFF
--- a/src-tauri/Cargo.lock
+++ b/src-tauri/Cargo.lock
@@ -50,6 +50,7 @@ dependencies = [
  "mouse_position",
  "objc",
  "once_cell",
+ "parking_lot",
  "rdev",
  "serde",
  "serde_json",

--- a/src-tauri/Cargo.toml
+++ b/src-tauri/Cargo.toml
@@ -27,6 +27,7 @@ rdev = "0.5.2"
 tauri-plugin-single-instance = { git = "https://github.com/tauri-apps/plugins-workspace", branch = "dev", version = "0.1.0" }
 cpuid = "0.1.1"
 sysinfo = "0.28.3"
+parking_lot = "0.12.1"
 
 [target.'cfg(target_os = "macos")'.dependencies]
 cocoa = "0.24"

--- a/src-tauri/src/main.rs
+++ b/src-tauri/src/main.rs
@@ -10,7 +10,9 @@ mod utils;
 mod windows;
 mod ocr;
 
+use std::sync::atomic::AtomicBool;
 use sysinfo::{CpuExt, System, SystemExt};
+use parking_lot::Mutex;
 
 use crate::config::get_config_content;
 use crate::windows::{MAIN_WIN_NAME, show_main_window_with_selected_text, get_main_window_always_on_top, set_main_window_always_on_top};
@@ -24,8 +26,8 @@ use tauri::api::notification::Notification;
 use window_shadows::set_shadow;
 
 pub static APP_HANDLE: OnceCell<AppHandle> = OnceCell::new();
-pub static mut ALWAYS_ON_TOP: bool = false;
-pub static mut CPU_VENDOR: String = String::new();
+pub static ALWAYS_ON_TOP: AtomicBool = AtomicBool::new(false);
+pub static CPU_VENDOR: Mutex<String> = Mutex::new(String::new());
 
 #[derive(Clone, serde::Serialize)]
 struct Payload {
@@ -52,11 +54,10 @@ fn query_accessibility_permissions() -> bool {
 fn main() {
     let mut sys = System::new();
     sys.refresh_cpu(); // Refreshing CPU information.
-    sys.cpus().iter().for_each(|cpu| {
-        unsafe {
-            CPU_VENDOR = cpu.vendor_id().to_string();
-        }
-    });
+    if let Some(cpu) = sys.cpus().first() {
+        let vendor_id = cpu.vendor_id().to_string();
+        *CPU_VENDOR.lock() = vendor_id;
+    }
     tauri::Builder::default()
         .plugin(tauri_plugin_single_instance::init(|app, argv, cwd| {
             println!("{}, {argv:?}, {cwd}", app.package_info().name);

--- a/src-tauri/src/ocr.rs
+++ b/src-tauri/src/ocr.rs
@@ -8,10 +8,8 @@ pub fn do_ocr() -> Result<(), Box<dyn std::error::Error>> {
     use crate::{CPU_VENDOR, APP_HANDLE};
 
     let mut rel_path = "resources/bin/ocr_intel".to_string();
-    unsafe {
-        if CPU_VENDOR == "Apple" {
-            rel_path = "resources/bin/ocr_apple".to_string();
-        }
+    if *CPU_VENDOR.lock() == "Apple" {
+        rel_path = "resources/bin/ocr_apple".to_string();
     }
 
     let bin_path = APP_HANDLE.get().unwrap().path_resolver()

--- a/src-tauri/src/tray.rs
+++ b/src-tauri/src/tray.rs
@@ -7,6 +7,7 @@ use crate::ALWAYS_ON_TOP;
 use crate::config::get_config;
 use crate::windows::{set_main_window_always_on_top, MAIN_WIN_NAME};
 use crate::ocr::ocr;
+use std::sync::atomic::Ordering;
 
 pub fn menu() -> SystemTray {
     let config = get_config().unwrap();
@@ -19,9 +20,7 @@ pub fn menu() -> SystemTray {
     let hide = CustomMenuItem::new("hide".to_string(), "Hide");
     let mut pin: CustomMenuItem = CustomMenuItem::new("pin".to_string(), "Pin");
     let quit = CustomMenuItem::new("quit".to_string(), "Quit");
-    unsafe {
-        pin.selected = ALWAYS_ON_TOP;
-    }
+    pin.selected = ALWAYS_ON_TOP.load(Ordering::Acquire);
     let tray_menu = SystemTrayMenu::new()
         .add_item(ocr)
         .add_native_item(SystemTrayMenuItem::Separator)


### PR DESCRIPTION
hi~ ~ this pr remove unsafe code, static mut in rust that may violate Rust memory security principles. 
making code more secure by using AtomicBool and Mutex to replace the same implementation. thanks~