### PR TITLE
fix: import cld-min.js

### DIFF
--- a/public/popup.html
+++ b/public/popup.html
@@ -8,6 +8,7 @@
   <body>
     <div id="root"></div>
     <script src="js/popup.js"></script>
+    <script src="js/cld-min.js"></script>
   </body>
 </html>
 


### PR DESCRIPTION
cld-min.js is not import when entering from the toolbar