### PR TITLE
Fix popup card settings check

### DIFF
--- a/src/content_script/PopupCard.tsx
+++ b/src/content_script/PopupCard.tsx
@@ -843,7 +843,11 @@ export function PopupCard(props: IPopupCardProps) {
         if (!props.defaultShowSettings) {
             return
         }
-        if (settings && !settings.apiKeys) {
+        if (
+            settings &&
+            ((settings.provider === 'ChatGPT' && !settings.apiModel) ||
+                (settings.provider !== 'ChatGPT' && !settings.apiKeys))
+        ) {
             setShowSettings(true)
         }
     }, [props.defaultShowSettings, settings])


### PR DESCRIPTION
It should not show the settings when we only use the web api.