### PR TITLE
fix: disable sentry on firefox

### DIFF
--- a/src/content_script/PopupCard.tsx
+++ b/src/content_script/PopupCard.tsx
@@ -22,7 +22,7 @@ import { clsx } from 'clsx'
 import { Button } from 'baseui-sd/button'
 import { ErrorBoundary } from 'react-error-boundary'
 import { ErrorFallback } from '../components/ErrorFallback'
-import { defaultAPIURL, exportToCsv, isDesktopApp, isTauri } from '../common/utils'
+import { defaultAPIURL, exportToCsv, isDesktopApp, isFirefox, isTauri } from '../common/utils'
 import { Settings } from '../popup/Settings'
 import { documentPadding } from './consts'
 import Dropzone from 'react-dropzone'
@@ -47,15 +47,16 @@ import { useCollectedWordTotal } from '../common/hooks/useCollectedWordTotal'
 import { Modal } from 'baseui-sd/modal'
 import * as Sentry from '@sentry/react'
 
-Sentry.init({
-    dsn: 'https://477519542bd6491cb347ca3f55fcdce6@o441417.ingest.sentry.io/4505051776090112',
-    integrations: [new Sentry.BrowserTracing(), new Sentry.Replay()],
-    // Performance Monitoring
-    tracesSampleRate: 0.5, // Capture 100% of the transactions, reduce in production!
-    // Session Replay
-    replaysSessionSampleRate: 0.1, // This sets the sample rate at 10%. You may want to change it to 100% while in development and then sample at a lower rate in production.
-    replaysOnErrorSampleRate: 1.0, // If you're not already sampling the entire session, change the sample rate to 100% when sampling sessions where errors occur.
-})
+!isFirefox &&
+    Sentry.init({
+        dsn: 'https://477519542bd6491cb347ca3f55fcdce6@o441417.ingest.sentry.io/4505051776090112',
+        integrations: [new Sentry.BrowserTracing(), new Sentry.Replay()],
+        // Performance Monitoring
+        tracesSampleRate: 0.5, // Capture 100% of the transactions, reduce in production!
+        // Session Replay
+        replaysSessionSampleRate: 0.1, // This sets the sample rate at 10%. You may want to change it to 100% while in development and then sample at a lower rate in production.
+        replaysOnErrorSampleRate: 1.0, // If you're not already sampling the entire session, change the sample rate to 100% when sampling sessions where errors occur.
+    })
 
 const cache = new LRUCache({
     max: 500,


### PR DESCRIPTION
`Sentry.init` causes Firefox to crash.

![1682576413732](https://user-images.githubusercontent.com/18044730/234778686-30b65990-eda5-468b-987b-f2399a3fade9.jpg)

----

After this, still doesn't work on Firefox due to `dexie`.

![1682576394449](https://user-images.githubusercontent.com/18044730/234779131-bbc5f91d-9cf1-4661-a949-cd2fa8b05f31.jpg)
